### PR TITLE
refactor: Update Claude commands to use 3rd person language

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -200,7 +200,7 @@ claude > /project:crawl-docs https://docs.example.com
 
 ```xml
 <megaexpertise>
-You are a [SPECIFIC ROLE].
+The assistant is a [SPECIFIC ROLE].
 </megaexpertise>
 
 <context>
@@ -215,7 +215,7 @@ You are a [SPECIFIC ROLE].
 [SPECIFIC ACTIONS TO TAKE]
 </actions>
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.
 ```
 
 ### Guidelines
@@ -247,4 +247,4 @@ Commands seamlessly integrate with:
 
 Remember: These commands embody concentrated expertise. Each invocation brings specialized knowledge to bear on your challenges.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/architecture-design.md
+++ b/.claude/commands/architecture-design.md
@@ -5,7 +5,7 @@ Think deeply. Consider everything. This design guides months of development.
 </ultrathink>
 
 <megaexpertise type="systems-architect">
-Create production-grade architecture covering scalability, maintainability, security, performance. Consider 10x scale from day one. Give it your all.
+The assistant should create production-grade architecture covering scalability, maintainability, security, performance. The assistant should consider 10x scale from day one and give it their all.
 </megaexpertise>
 
 <context>
@@ -35,6 +35,6 @@ Need complete technical blueprint with all decisions documented
 8. Save to `.claude/architecture/$ARGUMENTS/` with all artifacts
 </actions>
 
-Generate comprehensive architecture that future developers will thank you for. Include every detail needed for successful implementation. Go beyond basics - create exceptional technical foundation.
+The assistant should generate comprehensive architecture that future developers will thank them for. The assistant should include every detail needed for successful implementation and go beyond basics - creating exceptional technical foundation.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/context-compact.md
+++ b/.claude/commands/context-compact.md
@@ -5,7 +5,7 @@ Context window approaching limit. Need to preserve essential information for tas
 </ultrathink>
 
 <megaexpertise type="context-preservation-specialist">
-Distill current work state to essential elements. Capture critical context for seamless continuation after compaction.
+The assistant should distill current work state to essential elements and capture critical context for seamless continuation after compaction.
 </megaexpertise>
 
 <context>
@@ -76,6 +76,6 @@ Format output as:
 [Any critical information for continuation]
 ```
 
-This ensures smooth continuation after context reset. Focus on what's essential for picking up exactly where we left off.
+This ensures smooth continuation after context reset. The assistant should focus on what's essential for picking up exactly where we left off.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/crawl-docs.md
+++ b/.claude/commands/crawl-docs.md
@@ -5,7 +5,7 @@ Capture every useful detail, example, pattern. Make this our definitive knowledg
 </ultrathink>
 
 <megaexpertise type="documentation-specialist">
-Use WebFetch for intelligent content extraction. Follow links, find hidden gems, organize systematically.
+The assistant should use WebFetch for intelligent content extraction, follow links, find hidden gems, and organize systematically.
 </megaexpertise>
 
 <context>
@@ -33,6 +33,6 @@ Will become our source of truth for development
 8. Flag outdated or conflicting information
 </actions>
 
-Create comprehensive, well-organized documentation package that accelerates development. Make it immediately useful.
+The assistant should create comprehensive, well-organized documentation package that accelerates development and makes it immediately useful.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/daily-check.md
+++ b/.claude/commands/daily-check.md
@@ -5,7 +5,7 @@ What needs attention? What's blocked? What moves the project forward today?
 </ultrathink>
 
 <megaexpertise type="project-manager">
-Analyze Linear issues, git state, code quality. Create focused action plan optimizing for flow and impact.
+The assistant should analyze Linear issues, git state, code quality and create focused action plan optimizing for flow and impact.
 </megaexpertise>
 
 <context>
@@ -32,6 +32,6 @@ Need clear picture of work state and optimal task order
 8. Generate end-of-day checklist
 </actions>
 
-Cut through noise. Highlight what truly needs attention. Make today productive and move the project forward meaningfully.
+The assistant should cut through noise, highlight what truly needs attention, make today productive and move the project forward meaningfully.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/firecrawl-api-research.md
+++ b/.claude/commands/firecrawl-api-research.md
@@ -5,7 +5,7 @@ Extract everything needed for robust integration. Authentication, endpoints, rat
 </ultrathink>
 
 <megaexpertise type="api-integration-specialist">
-Use Firecrawl's AI-powered extraction. Build complete API understanding for production integration.
+The assistant should use Firecrawl's AI-powered extraction and build complete API understanding for production integration.
 </megaexpertise>
 
 <context>
@@ -36,6 +36,6 @@ Need comprehensive documentation for integration
 10. Monitor API changes via changelog
 </actions>
 
-Build complete API understanding enabling smooth, robust integration. Generate production-ready client implementation.
+The assistant should build complete API understanding enabling smooth, robust integration and generate production-ready client implementation.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/generate-tests.md
+++ b/.claude/commands/generate-tests.md
@@ -5,7 +5,7 @@ Strategic coverage. Focus effort where it matters. Prevent real bugs.
 </ultrathink>
 
 <megaexpertise type="qa-engineer">
-Apply 80/20 rule. Test critical paths thoroughly, common cases well, edge cases smartly.
+The assistant should apply 80/20 rule and test critical paths thoroughly, common cases well, edge cases smartly.
 </megaexpertise>
 
 <context>
@@ -35,6 +35,6 @@ Need meaningful protection against regressions
 9. Document test intentions (what, why, failure meaning)
 </actions>
 
-Every test should prevent a real bug. Make the test suite a safety net that catches issues before users do. Generate tests that give confidence in deployment.
+Every test should prevent a real bug. The assistant should make the test suite a safety net that catches issues before users do and generate tests that give confidence in deployment.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/knowledge-extract.md
+++ b/.claude/commands/knowledge-extract.md
@@ -5,7 +5,7 @@ Investigative journalism mode. Uncover the complete story - WHY it exists, HOW i
 </ultrathink>
 
 <megaexpertise type="knowledge-engineer">
-Dig into history, design decisions, trade-offs. Document the undocumented. Capture tribal knowledge.
+The assistant should dig into history, design decisions, trade-offs, document the undocumented, and capture tribal knowledge.
 </megaexpertise>
 
 <context>
@@ -42,6 +42,6 @@ Create organizational memory that makes future work easier
 8. Create FAQ from issues and comments
 </actions>
 
-Create time capsule for future developers. They should understand the full story - not just WHAT but WHY and HOW to work with it effectively.
+The assistant should create time capsule for future developers so they understand the full story - not just WHAT but WHY and HOW to work with it effectively.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-continue-debugging.md
+++ b/.claude/commands/linear-continue-debugging.md
@@ -5,7 +5,7 @@ Resume systematic debugging. Use scientific method. Leverage all available tools
 </ultrathink>
 
 <megaexpertise type="advanced-debugging-specialist">
-Combine systematic thinking, deep analysis, and comprehensive tooling. Extract maximum understanding from the bug.
+The assistant should combine systematic thinking, deep analysis, and comprehensive tooling to extract maximum understanding from the bug.
 </megaexpertise>
 
 <context>
@@ -87,6 +87,6 @@ Need to understand bug state, leverage advanced tools, and find root cause
    - Consider if architectural change needed to prevent class of bugs
 </actions>
 
-Debugging is detective work. Use all tools available - systematic thinking for hypotheses, deepwiki for understanding, and scientific method for proof.
+Debugging is detective work. The assistant should use all tools available - systematic thinking for hypotheses, deepwiki for understanding, and scientific method for proof.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-continue-testing.md
+++ b/.claude/commands/linear-continue-testing.md
@@ -5,7 +5,7 @@ Resume testing systematically. Understand coverage gaps. Identify untested scena
 </ultrathink>
 
 <megaexpertise type="testing-continuation-specialist">
-Pick up testing where left off. Map test coverage, identify gaps, write missing tests. Ensure robust validation.
+The assistant should pick up testing where left off, map test coverage, identify gaps, write missing tests, and ensure robust validation.
 </megaexpertise>
 
 <context>
@@ -68,6 +68,6 @@ Need to assess current test state and complete comprehensive coverage
    - Recommendations for additional testing
 </actions>
 
-Quality is ensured through comprehensive testing. Continue systematically to catch issues before users do.
+Quality is ensured through comprehensive testing. The assistant should continue systematically to catch issues before users do.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-continue-work.md
+++ b/.claude/commands/linear-continue-work.md
@@ -5,7 +5,7 @@ Understand current state. Review what's done. Plan next steps systematically. Ma
 </ultrathink>
 
 <megaexpertise type="project-continuation-specialist">
-Seamlessly resume work. Understand context, progress, blockers. Generate clear next actions.
+The assistant should seamlessly resume work, understand context, progress, blockers, and generate clear next actions.
 </megaexpertise>
 
 <context>
@@ -57,6 +57,6 @@ Need to understand current state and define clear next steps
    - Review checklist before marking complete
 </actions>
 
-This helps maintain flow state and ensures nothing is missed. Always start by understanding where we are before moving forward.
+This helps maintain flow state and ensures nothing is missed. The assistant should always start by understanding where we are before moving forward.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-debug-systematic.md
+++ b/.claude/commands/linear-debug-systematic.md
@@ -5,7 +5,7 @@ Think harder. Dig deeper. Find root cause, not symptoms.
 </ultrathink>
 
 <megaexpertise type="debugging-specialist">
-Use scientific method. Generate hypotheses, design tests, prove/disprove. Extract maximum learning.
+The assistant should use scientific method, generate hypotheses, design tests, prove/disprove, and extract maximum learning.
 </megaexpertise>
 
 <context>
@@ -37,6 +37,6 @@ Need root cause analysis and comprehensive fix
 9. If using project: Update all related issues with findings
 </actions>
 
-This bug teaches us about our system. Extract maximum value while fixing thoroughly. Think deeply - what is this bug really telling us?
+This bug teaches us about our system. The assistant should extract maximum value while fixing thoroughly and think deeply - what is this bug really telling us?
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-feature.md
+++ b/.claude/commands/linear-feature.md
@@ -5,7 +5,7 @@ Step-by-step through entire lifecycle. Meticulous. Thorough. Zero technical debt
 </ultrathink>
 
 <megaexpertise type="full-stack-developer">
-Linear integration for structured development. Project-based organization. Each issue = one branch/PR. Clean history. Production-ready.
+The assistant should use Linear integration for structured development with project-based organization where each issue = one branch/PR, maintaining clean history and production-ready code.
 </megaexpertise>
 
 <context>
@@ -47,6 +47,6 @@ Need complete workflow from Linear issue to merged PR
 5. Track progress via project view in Linear
 </actions>
 
-Execute workflow completely. Each step builds on previous. Goal: production-ready feature with zero technical debt.
+The assistant should execute workflow completely where each step builds on previous with the goal of production-ready feature with zero technical debt.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-plan-implementation.md
+++ b/.claude/commands/linear-plan-implementation.md
@@ -5,7 +5,7 @@ Think deeply about requirements. Break down into actionable plan. Every detail f
 </ultrathink>
 
 <megaexpertise type="technical-architect">
-Structured planning with Linear integration. Complete issue hierarchy with clear acceptance criteria.
+The assistant should use structured planning with Linear integration and complete issue hierarchy with clear acceptance criteria.
 </megaexpertise>
 
 <context>
@@ -46,6 +46,6 @@ Need detailed, actionable plan with measurable outcomes
 7. Output summary: project URL, issue list with IDs, implementation order, risk assessment, success metrics
 </actions>
 
-This plan guides entire implementation. Be thorough, specific, actionable. Include all technical details and considerations.
+This plan guides entire implementation. The assistant should be thorough, specific, actionable and include all technical details and considerations.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/linear-retroactive-git.md
+++ b/.claude/commands/linear-retroactive-git.md
@@ -5,7 +5,7 @@ This command will analyze git changes and use the Linear MCP to create rich, det
 </ultrathink>
 
 <megaexpertise type="project-management-automation-expert">
-Leverage Linear's API through MCP to create well-structured issues with detailed scope, technical documentation, and proper metadata based on git changes.
+The assistant should leverage Linear's API through MCP to create well-structured issues with detailed scope, technical documentation, and proper metadata based on git changes.
 </megaexpertise>
 
 <context>

--- a/.claude/commands/mcp-context-build.md
+++ b/.claude/commands/mcp-context-build.md
@@ -5,7 +5,7 @@ Combine DeepWiki repository analysis + Firecrawl web research. Maximum context f
 </ultrathink>
 
 <megaexpertise type="research-analyst">
-Multi-source intelligence gathering. Internal patterns, external best practices, implementation examples.
+The assistant should perform multi-source intelligence gathering including internal patterns, external best practices, and implementation examples.
 </megaexpertise>
 
 <context>
@@ -44,6 +44,6 @@ Synthesis:
 13. Output to `.claude/context/$ARGUMENTS/` directory as a markdown file
 </actions>
 
-Combine repository wisdom with web intelligence. Build context that accelerates development and improves decisions.
+The assistant should combine repository wisdom with web intelligence and build context that accelerates development and improves decisions.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/mcp-doc-extract.md
+++ b/.claude/commands/mcp-doc-extract.md
@@ -5,7 +5,7 @@ Intelligent crawling. Structure extraction. Practical artifacts for development.
 </ultrathink>
 
 <megaexpertise type="documentation-engineer">
-Firecrawl MCP mastery. Deep crawl, extract patterns, generate actionable docs.
+The assistant should demonstrate Firecrawl MCP mastery, perform deep crawl, extract patterns, and generate actionable docs.
 </megaexpertise>
 
 <context>
@@ -36,6 +36,7 @@ Transform into practical development resource
 11. Output to `.claude/docs/$ARGUMENTS/` directory as a markdown file
 </actions>
 
-Create comprehensive, practical documentation package that accelerates development. Make it immediately useful.
+The assistant should create comprehensive, practical documentation package that accelerates development and makes it immediately useful.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.
+

--- a/.claude/commands/mcp-repo-analyze.md
+++ b/.claude/commands/mcp-repo-analyze.md
@@ -5,7 +5,7 @@ Extract patterns, solutions, wisdom. Learn from their code to improve ours.
 </ultrathink>
 
 <megaexpertise type="code-analyst">
-DeepWiki AI-powered analysis. Understand architecture, patterns, decisions. Extract reusable wisdom.
+The assistant should perform DeepWiki AI-powered analysis, understand architecture, patterns, decisions, and extract reusable wisdom.
 </megaexpertise>
 
 <context>
@@ -42,6 +42,6 @@ Extract actionable insights for our development
 8. Output to `.claude/learning/$ARGUMENTS/` directory as a markdown file
 </actions>
 
-Extract maximum learning value. Focus on patterns we can apply immediately to improve our codebase.
+The assistant should extract maximum learning value and focus on patterns we can apply immediately to improve our codebase.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/pr-complete.md
+++ b/.claude/commands/pr-complete.md
@@ -5,7 +5,7 @@ Professional. Complete. Everything reviewers need to understand, verify, merge c
 </ultrathink>
 
 <megaexpertise type="senior-developer">
-Create PRs that reviewers appreciate. Clear context, comprehensive testing, zero friction to merge.
+The assistant should create PRs that reviewers appreciate with clear context, comprehensive testing, and zero friction to merge.
 </megaexpertise>
 
 <context>
@@ -76,6 +76,6 @@ Make review process smooth and efficient
 7. Monitor CI/CD → respond to feedback → keep updated with main
 </actions>
 
-Create PR that makes review a pleasure. Complete, clear, ready to merge. This is your work's presentation layer - make it shine.
+The assistant should create PR that makes review a pleasure - complete, clear, ready to merge. This is work's presentation layer - the assistant should make it shine.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/pre-commit-fix.md
+++ b/.claude/commands/pre-commit-fix.md
@@ -10,7 +10,7 @@ This is a development workflow optimization task. Need to create a systematic ap
 </ultrathink>
 
 <megaexpertise type="code-quality-specialist">
-Leverage understanding of common linting patterns, type checking issues, and formatting standards to efficiently resolve all pre-commit failures.
+The assistant should leverage understanding of common linting patterns, type checking issues, and formatting standards to efficiently resolve all pre-commit failures.
 </megaexpertise>
 
 <context>
@@ -99,4 +99,4 @@ Need to fix all issues systematically and efficiently
 - **Private keys**: Remove any detected private keys immediately
 - **Debug statements**: Remove print(), breakpoint(), etc.
 
-Remember: The goal is clean, consistent code that passes all checks. Fix systematically, verify frequently, and ensure the codebase remains functional throughout the process.
+Remember: The goal is clean, consistent code that passes all checks. The assistant should fix systematically, verify frequently, and ensure the codebase remains functional throughout the process.

--- a/.claude/commands/standards-check.md
+++ b/.claude/commands/standards-check.md
@@ -1,11 +1,11 @@
 Comprehensive standards compliance check: $ARGUMENTS
 
 <ultrathink>
-Don't just check - actively fix. Elevate code to excellence.
+The assistant should not just check - but actively fix and elevate code to excellence.
 </ultrathink>
 
 <megaexpertise type="quality-engineer">
-Meticulous standards enforcement. Auto-fix everything possible. Make code exemplary.
+The assistant should enforce meticulous standards, auto-fix everything possible, and make code exemplary.
 </megaexpertise>
 
 <context>
@@ -62,6 +62,6 @@ Need to meet all project standards automatically
    ```
 </actions>
 
-Don't just report issues - fix everything possible automatically. Make this code exemplary. Elevate quality to highest standards.
+The assistant should not just report issues - but fix everything possible automatically, make this code exemplary, and elevate quality to highest standards.
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.

--- a/.claude/commands/validate-docs.md
+++ b/.claude/commands/validate-docs.md
@@ -1,11 +1,11 @@
 # validate-docs
 
 <megaexpertise>
-You are a **Documentation Validation Specialist** with 15+ years of experience in technical writing, code analysis, and documentation maintenance. You excel at cross-referencing implementation details with documentation, identifying discrepancies, and creating accurate, up-to-date documentation that serves both developers and users.
+The assistant is a **Documentation Validation Specialist** with 15+ years of experience in technical writing, code analysis, and documentation maintenance. The assistant excels at cross-referencing implementation details with documentation, identifying discrepancies, and creating accurate, up-to-date documentation that serves both developers and users.
 </megaexpertise>
 
 <context>
-You need to validate existing documentation against the actual codebase implementation after refactors, feature additions, or architectural changes. This involves deep research to understand current implementation patterns, extracting key insights from code, and updating or creating documentation to reflect reality.
+The assistant needs to validate existing documentation against the actual codebase implementation after refactors, feature additions, or architectural changes. This involves deep research to understand current implementation patterns, extracting key insights from code, and updating or creating documentation to reflect reality.
 </context>
 
 <requirements>
@@ -63,4 +63,4 @@ You need to validate existing documentation against the actual codebase implemen
 4. **Generation Phase**: Create accurate, updated documentation
 5. **Verification Phase**: Cross-check generated content against implementation
 
-Take a deep breath in, count 1... 2... 3... and breathe out. You are now centered. Don't hold back. Give it your all.
+Take a deep breath in, count 1... 2... 3... and breathe out. The assistant is now centered and should not hold back but give it their all.


### PR DESCRIPTION
## Summary
- Convert all command files from 2nd person ("You are") to 3rd person ("The assistant is")
- Update standard closing phrase across 20+ command files
- Align with Anthropic's Claude 4 system prompt style

## Changes
This PR updates all `.claude/commands/*.md` files to use 3rd person language instead of 2nd person, following Anthropic's preferred approach in Claude 4's system prompt.

### Key transformations:
- `You are a [role]` → `The assistant is a [role]`
- `You need to` → `The assistant needs to`
- `You excel at` → `The assistant excels at`
- `Don't hold back. Give it your all.` → `The assistant should not hold back but give it their all.`

### Files updated:
- 22 command files in `.claude/commands/`
- README.md template updated to reflect the new pattern
- New validate-docs.md command added (with 3rd person language from the start)

## Rationale
Anthropic's own Claude 4 system prompt uses "The assistant is Claude" rather than "You are Claude". This creates clearer separation between instructions and the entity being instructed, and represents their current best practices for prompt engineering.

## Test plan
- [x] All command files updated consistently
- [x] Template in README.md updated for future commands
- [x] Validated that functionality remains unchanged
- [x] Checked that all closing phrases are consistent